### PR TITLE
Removed targets file from NuGet package creation to fixed issue #8

### DIFF
--- a/Packaging/Content/Microsoft.IoT.DeviceCore/build/Microsoft.IoT.DeviceCore.targets
+++ b/Packaging/Content/Microsoft.IoT.DeviceCore/build/Microsoft.IoT.DeviceCore.targets
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <SDKReference Include="WindowsIoT, Version=10.0.10240.0">
-      <Name>Windows IoT Extensions for the UWP</Name>
-    </SDKReference>
-  </ItemGroup>
-</Project>


### PR DESCRIPTION
Removing this file will fixed the problem with `Windows.Devices.DevicesLowLevelContract` when adding the NuGet packages to projects using newer SDKs as described in issue #8  
